### PR TITLE
Add crashlytics Build ID to automatic white list

### DIFF
--- a/wiki/en/WHITELIST.md
+++ b/wiki/en/WHITELIST.md
@@ -12,4 +12,5 @@ Welcome PR your configs which is not included in whitelist.
 *.R.string.google_crash_reporting_api_key
 *.R.string.google_storage_bucket
 *.R.string.project_id
+*.R.string.com.crashlytics.android.build_id
 ```


### PR DESCRIPTION
Without this, every app which have integrated Crashlytics will crash after resource obfuscation