### PR TITLE
Ignore lines not starting with white space when parsing

### DIFF
--- a/core/src/main/java/com/bytedance/android/aabresguard/parser/ResourcesMappingParser.java
+++ b/core/src/main/java/com/bytedance/android/aabresguard/parser/ResourcesMappingParser.java
@@ -16,8 +16,8 @@ import static com.android.tools.build.bundletool.model.utils.files.FilePrecondit
  * Email: yangjing.yeoh@bytedance.com
  */
 public class ResourcesMappingParser {
-    private static final Pattern MAP_DIR_PATTERN = Pattern.compile("\\s+(.*)->(.*)");
-    private static final Pattern MAP_RES_PATTERN = Pattern.compile("\\s+(.*):(.*)->(.*)");
+    private static final Pattern MAP_DIR_PATTERN = Pattern.compile("^\\s+(.*)->(.*)");
+    private static final Pattern MAP_RES_PATTERN = Pattern.compile("^\\s+(.*):(.*)->(.*)");
     private final Path mappingPath;
 
     public ResourcesMappingParser(Path mappingPath) {


### PR DESCRIPTION
This allows you to comment out lines, e.g. using '#'.

For example:
```
res dir mapping:
	res/anim -> res/a
	res/color -> res/b
#	res/drawable -> res/c
#	res/interpolator -> res/d
	res/layout -> res/e
	res/menu -> res/f
	res/raw -> res/g
	res/xml -> res/h
```